### PR TITLE
Allow body replacement to be overridden

### DIFF
--- a/src/simple-pjax.js
+++ b/src/simple-pjax.js
@@ -50,6 +50,10 @@ const pjax = {
       'data-noscroll': true,
       'data-force-reload': true
     }))
+  },
+
+  replaceBody (newBody) {
+    document.body = newBody
   }
 }
 
@@ -335,7 +339,7 @@ function replaceDocument (doc: HTMLDocument) {
   removeScriptsWithSrc(doc)
 
   // Replace the body.
-  document.body = doc.body
+  pjax.replaceBody(doc.body)
 
   // Execute inline scripts found in the new document. Creating copies and
   // adding them to the DOM (instead of using `new Function(...)()` to eval)


### PR DESCRIPTION
I'd like to use `simple-pjax` with libraries like https://github.com/DylanPiercey/set-dom to change the behavior of the body replacement. (In this case, to make using CSS transitions possible cross-pageload.)

This PR doesn't change behavior for existing users, but allows folks who want to override the default body replacement behavior to do so.